### PR TITLE
Viper avionics updates

### DIFF
--- a/Sim/Acdata/f16bk15.dat
+++ b/Sim/Acdata/f16bk15.dat
@@ -1463,7 +1463,7 @@ avionicsCanUseSpice 0
 avionicsJDAMAvionicsType 0
 avionicsDiffICPStyle 0
 avionicsMLUPFL 0
-avionicsDatalink 1
+avionicsDatalink 3
 avionicsDLCursorAsWaypoint 0
 avionicsDteIdmLabel 0
 avionicsHudLadderTapeType 2
@@ -1493,7 +1493,7 @@ avionicsMMCUpgrade 0
 avionicsEGIUpgrade 0
 avionicsDigitalFLCS 0
 avionicsRWRType 2
-avionicsGunEEGSMode 1
+avionicsGunEEGSMode 0
 avionicsGunSSLCMode 1
 avionicsGunLCOSMode 1
 avionicsGunSNAPMode 1

--- a/Sim/Acdata/f16bk25.dat
+++ b/Sim/Acdata/f16bk25.dat
@@ -1466,7 +1466,7 @@ avionicsCanUseSpice 0
 avionicsJDAMAvionicsType 0
 avionicsDiffICPStyle 0
 avionicsMLUPFL 0
-avionicsDatalink 2
+avionicsDatalink 3
 avionicsDLCursorAsWaypoint 0
 avionicsDteIdmLabel 0
 avionicsHudLadderTapeType 1
@@ -1496,10 +1496,10 @@ avionicsMMCUpgrade 0
 avionicsEGIUpgrade 1
 avionicsDigitalFLCS 0
 avionicsRWRType 2
-avionicsGunEEGSMode 1
-avionicsGunSSLCMode 0
-avionicsGunLCOSMode 0
-avionicsGunSNAPMode 0
+avionicsGunEEGSMode 0
+avionicsGunSSLCMode 1
+avionicsGunLCOSMode 1
+avionicsGunSNAPMode 1
 avionicsEngineType 1
 avionicsMfdCataSymbolAim120 0
 avionicsHudOldBAIType 0

--- a/Sim/Acdata/f16bk30.dat
+++ b/Sim/Acdata/f16bk30.dat
@@ -1559,7 +1559,7 @@ avionicsCanUseSpice 0
 avionicsJDAMAvionicsType 0
 avionicsDiffICPStyle 0
 avionicsMLUPFL 0
-avionicsDatalink 2
+avionicsDatalink 3
 avionicsDLCursorAsWaypoint 0
 avionicsDteIdmLabel 0
 avionicsHudLadderTapeType 2
@@ -1582,14 +1582,14 @@ avionicsRadarJamChevrons 0
 avionicsRadarVsMode 1
 avionicsRadarLrsMode 1
 avionicsRadarUlsMode 1
-avionicsColorMfd 1 #uri_ba 12/07/2015
+avionicsColorMfd 0 #uri_ba 12/07/2015
 avionicsGrayScaleGM 0
 avionicsActivateMFDBoot 2 #uri_ba 12/07/2015
 avionicsMMCUpgrade 0
 avionicsEGIUpgrade 0
 avionicsDigitalFLCS 0
 avionicsRWRType 2
-avionicsGunEEGSMode 1
+avionicsGunEEGSMode 0
 avionicsGunSSLCMode 1
 avionicsGunLCOSMode 1
 avionicsGunSNAPMode 1

--- a/Sim/Acdata/f16bk40.dat
+++ b/Sim/Acdata/f16bk40.dat
@@ -1557,7 +1557,7 @@ avionicsCanUseSpice 0
 avionicsJDAMAvionicsType 0
 avionicsDiffICPStyle 0
 avionicsMLUPFL 0
-avionicsDatalink 2
+avionicsDatalink 3
 avionicsDLCursorAsWaypoint 0
 avionicsDteIdmLabel 0
 avionicsHudLadderTapeType 0
@@ -1580,17 +1580,17 @@ avionicsRadarJamChevrons 1
 avionicsRadarVsMode 1
 avionicsRadarLrsMode 1
 avionicsRadarUlsMode 1
-avionicsColorMfd 1
+avionicsColorMfd 0
 avionicsGrayScaleGM 1
 avionicsActivateMFDBoot 1 #uri_ba 12/07/2015
 avionicsMMCUpgrade 1
 avionicsEGIUpgrade 1
 avionicsDigitalFLCS 1
 avionicsRWRType 1
-avionicsGunEEGSMode 1
-avionicsGunSSLCMode 0
-avionicsGunLCOSMode 0
-avionicsGunSNAPMode 0
+avionicsGunEEGSMode 0
+avionicsGunSSLCMode 1
+avionicsGunLCOSMode 1
+avionicsGunSNAPMode 1
 avionicsEngineType 2
 avionicsMfdCataSymbolAim120 0
 avionicsHudOldBAIType 0

--- a/Terrdata/Objects/FALCON4_VCD.XML
+++ b/Terrdata/Objects/FALCON4_VCD.XML
@@ -4501,7 +4501,7 @@
     <VCD Num="59">
         <CtIdx>173</CtIdx>
         <HitPoints>60</HitPoints>
-        <Flags>1611400192</Flags>
+        <Flags>1074529280</Flags>
         <Name>F-16CM-40</Name>
         <NCTR>F16</NCTR>
         <RadarCs>1.000000</RadarCs>


### PR DESCRIPTION
Remove datalink, color MFD and EEGS from the following:
- F-16A block 15
- F-16C block 25
- F-16C block 30
- F-16C block 40

Also removed HMCS from block 40.

https://trello.com/c/vikgGtqx
https://trello.com/c/kgj8DTLp
https://trello.com/c/FeEEh5sa
https://trello.com/c/AJK0pPsg