### PR TITLE
Release refactor

### DIFF
--- a/make_release.py
+++ b/make_release.py
@@ -33,8 +33,7 @@ def deleteFolderAndFiles(path):
 deleteFolderAndFiles(tempWorkingDirRoot)
 
 print ("git clone starting...")
-# Had to do this because git clone is throwing access denied without it, probably due to a race condition with rmtree
-time.sleep(2)
+time.sleep(2) # Had to do this because git clone is throwing access denied without it, probably due to a race condition with rmtree
 Repo.clone_from("https://github.com/tyrspawn/kuwaitmodded", tempWorkingDir)
 print("git clone done")
 
@@ -46,7 +45,7 @@ def get_theater_version():
         for line in tdf:
             if line.startswith('desc'):
                 version_token = line.split()[-1].strip()
-                print (version_token)
+                print ("Preparing version ", version_token)
                 return version_token
     raise ValueError("Version not found in theater")
 
@@ -62,7 +61,7 @@ for file in blackListFiles:
 # delete .git dir from working dir
 deleteFolderAndFiles(os.path.join(tempWorkingDir,".git"))
 
-print ("Starting zip archive to ", os.path.dirname(".."))
+print ("Starting zip archive to ", os.path.dirname(os.path.abspath(__file__ + "/..")))
 shutil.make_archive((os.path.join('..', 'Kuwait UOAF.{}'.format(ver))), 'zip', tempWorkingDirRoot)
 print ("Finished archive")
 

--- a/make_release.py
+++ b/make_release.py
@@ -1,15 +1,48 @@
+# Run from cloned local repo, has a dependency on being run from an LFS enabled repo directory
 import os
 import zipfile
+import git
+import shutil
+import time
+import stat
+from git import Repo
+
+tempWorkingDir = "../repoCheckOutTemp"
+
+'''
+Error handler function
+It will try to change file permission and call the calling function again,
+'''
+def handleError(func, path, exc_info):
+    print('Handling Error for file ' , path)
+    print(exc_info)
+    # Check if file access issue
+    if not os.access(path, os.W_OK):
+       # Try to change the permision of file
+       os.chmod(path, stat.S_IWUSR)
+       # call the calling function again
+       func(path)
+
+try:
+    print("Trying to delete working dir")
+    shutil.rmtree(tempWorkingDir, ignore_errors=False, onerror=handleError)
+except OSError as e:
+    print ("Error: %s - %s." % (e.filename, e.strerror))
+
+print ("git clone starting...")
+# Had to do this because git clone is throwing access denied without it, probably due to a race condition with rmtree
+time.sleep(2)
+Repo.clone_from("https://github.com/tyrspawn/kuwaitmodded", tempWorkingDir)
+print("git clone done")
 
 def get_theater_version():
-    with open(os.path.join('TerrData', 'theaterdefinition', 'kuwait.tdf'), 'r') as tdf:
+    with open(os.path.join(tempWorkingDir, 'TerrData', 'theaterdefinition', 'kuwait.tdf'), 'r') as tdf:
         for line in tdf:
             if line.startswith('desc'):
                 version_token = line.split()[-1].strip()
+                print (version_token)
                 return version_token
     raise ValueError("Version not found in theater")
-
-
 
 def zipdir(path, ziph):
     # ziph is zipfile handle
@@ -19,13 +52,7 @@ def zipdir(path, ziph):
                 filesystem_path = os.path.normpath(os.path.join(root, file))
                 if filesystem_path.startswith('.git'):
                     continue
-                if filesystem_path.lower().startswith('campaign'):
-                    if filesystem_path.lower().endswith('.cam'):
-                        f = file.lower()
-                        if f not in ('save0.cam', 'save1.cam', 'save2.cam'):
-                            continue
-
-                    
+                
                 archive_path = os.path.join('Add-On Kuwait UOAF', filesystem_path)
                 print(filesystem_path)
                 ziph.write(filesystem_path, arcname=archive_path)
@@ -34,5 +61,10 @@ def zipdir(path, ziph):
 if __name__ == '__main__':
     ver = get_theater_version()
     with zipfile.ZipFile(os.path.join('..', 'Kuwait UOAF.{}.zip'.format(ver)), 'w', zipfile.ZIP_DEFLATED) as zipf:
-        zipdir('.', zipf)
-    
+        zipdir(tempWorkingDir, zipf)
+        try:
+            print("Try deleting working dir")
+            shutil.rmtree(tempWorkingDir, ignore_errors=False, onerror=handleError)
+        except OSError as e:
+            print ("Error: %s - %s." % (e.filename, e.strerror))
+        print(filesystem_path)


### PR DESCRIPTION
Major changes

- Clones master to a working directory one level above the __file__ directory 
- Prepares the working directory for release, uses a blacklist to remove files, and file operations to copy the readme 
- More verbose terminal output 
- Now uses shutil.make_archive to write the zip