### PR TITLE
Changed the Catapult setting, and added the launchbar to the F-14.

### DIFF
--- a/Sim/Acdata/f14a.dat
+++ b/Sim/Acdata/f14a.dat
@@ -641,14 +641,6 @@ DoorDelayUp6 1.50
 DoorDelayUp7 1.50
 DoorDelayUp8 1.50
 #-----------------------------------------------------
-# OLD Catapult
-#-----------------------------------------------------
-#CATAPULTDist 150.0
-#COMPRESSIONPerc 30.0 #Falcas 05/23/2014
-#CarrierLatFrictionFactor 3.0
-#CatGearStiffDecomp 3.0
-#CatXOffset 20.0 #Added Falcas 11/12/2014
-#-----------------------------------------------------
 # Catapult
 #-----------------------------------------------------
 CATAPULTDist 150.0

--- a/Sim/Acdata/f14a.dat
+++ b/Sim/Acdata/f14a.dat
@@ -641,13 +641,27 @@ DoorDelayUp6 1.50
 DoorDelayUp7 1.50
 DoorDelayUp8 1.50
 #-----------------------------------------------------
+# OLD Catapult
+#-----------------------------------------------------
+#CATAPULTDist 150.0
+#COMPRESSIONPerc 30.0 #Falcas 05/23/2014
+#CarrierLatFrictionFactor 3.0
+#CatGearStiffDecomp 3.0
+#CatXOffset 20.0 #Added Falcas 11/12/2014
+#-----------------------------------------------------
 # Catapult
 #-----------------------------------------------------
 CATAPULTDist 150.0
-COMPRESSIONPerc 30.0 #Falcas 05/23/2014
+COMPRESSIONPerc 5.0
 CarrierLatFrictionFactor 3.0
 CatGearStiffDecomp 3.0
 CatXOffset 20.0 #Added Falcas 11/12/2014
+#-----------------------------------------------------
+# Launchbar
+#-----------------------------------------------------
+hasLaunchBar 1
+LaunchBarMinAngle 0.0
+LaunchBarMaxAngle 80.0
 #-----------------------------------------------------
 # Hook
 #-----------------------------------------------------


### PR DESCRIPTION
1. This is my first contribution just to see if I'm understanding the workflow, so don't get too excited; it's meant to be simple.
2. This update fixes the F-14a for human carrier takeoffs by changing the Catapult setting and adding a launchbar to the F14a flight model. This is an ACDATA change.
3. The source for the fix is here: https://www.benchmarksims.org/forum/showthread.php?36248-F-A-18E-LAUNCH-BAR&highlight=launchbar